### PR TITLE
simplified tjm data check process, renamed object properties, removed port/ http check

### DIFF
--- a/cmds/asset.js
+++ b/cmds/asset.js
@@ -36,20 +36,20 @@ exports.builder = (yargs) => {
         .example('tjm asset deploy -c clustername, tjm asset update or tjm asset status');
 };
 exports.handler = (argv, _testTjmFunctions) => {
-    const tjmObject = _.clone(argv);
+    const tjmConfig = _.clone(argv);
 
     try {
-        tjmObject.asset_file_content = require(path.join(process.cwd(), 'asset/asset.json'));
+        tjmConfig.asset_file_content = require(path.join(process.cwd(), 'asset/asset.json'));
     } 
     catch (error) {
         reply.fatal(error);
     }
 
-    dataChecks(tjmObject).getAssetClusters();
-    const tjmFunctions = _testTjmFunctions || require('./cmd_functions/functions')(tjmObject);
+    dataChecks(tjmConfig).getAssetClusters();
+    const tjmFunctions = _testTjmFunctions || require('./cmd_functions/functions')(tjmConfig);
 
     function latestAssetVersion(cluster) {
-        const assetName = tjmObject.asset_file_content.name;
+        const assetName = tjmConfig.asset_file_content.name;
         const teraslice = require('teraslice-client-js')({
             host: `${cluster}`
         });
@@ -79,7 +79,7 @@ exports.handler = (argv, _testTjmFunctions) => {
         return tjmFunctions.loadAsset()
             .catch((err) => {
                 if (err.name === 'RequestError') {
-                    reply.fatal(`Could not connect to ${tjmObject.cluster}`);
+                    reply.fatal(`Could not connect to ${tjmConfig.cluster}`);
                 }
                 reply.fatal(err);
             });
@@ -106,16 +106,16 @@ exports.handler = (argv, _testTjmFunctions) => {
                             }
                         });
                 }
-                if(_.has(tjmObject, 'clusters')) {
-                    return tjmObject.clusters.forEach(cluster => postAssets(cluster));
+                if(_.has(tjmConfig, 'clusters')) {
+                    return tjmConfig.clusters.forEach(cluster => postAssets(cluster));
                 }
-                return postAssets(tjmObject.cluster);
+                return postAssets(tjmConfig.cluster);
             })
             .catch(err => reply.fatal((err.message)));
     } else if (argv.cmd === 'status') {
-        if(_.has(tjmObject, 'clusters')) {
-            return Promise.each(tjmObject.clusters, cluster => latestAssetVersion(cluster));
+        if(_.has(tjmConfig, 'clusters')) {
+            return Promise.each(tjmConfig.clusters, cluster => latestAssetVersion(cluster));
         }
-        return latestAssetVersion(tjmObject.cluster);
+        return latestAssetVersion(tjmConfig.cluster);
     }
 };

--- a/cmds/asset.js
+++ b/cmds/asset.js
@@ -80,7 +80,6 @@ exports.handler = (argv, _testTjmFunctions) => {
             .catch((err) => {
                 if (err.name === 'RequestError') {
                     reply.fatal(`Could not connect to ${tjmObject.cluster}`);
-                    return;
                 }
                 reply.fatal(err);
             });

--- a/cmds/asset.js
+++ b/cmds/asset.js
@@ -105,9 +105,10 @@ exports.handler = (argv, _testTjmFunctions) => {
             })
             .then(() => fs.readFile(`${process.cwd()}/builds/processors.zip`))
             .then((zippedFileData) => {
-                function postAssets(cName) {
+                function postAssets(cluster) {
+                    console.log(cluster);
                     const teraslice = require('teraslice-client-js')({
-                        host: `${tjmFunctions.httpClusterNameCheck(cName)}`
+                        host: `${cluster}`
                     });
                     return teraslice.assets.post(zippedFileData);
                 }
@@ -122,7 +123,7 @@ exports.handler = (argv, _testTjmFunctions) => {
                             }
                         })
                         .catch((err) => {
-                            reply.fatal(err);
+                            reply.fatal(err.stack);
                         });
                 });
             })

--- a/cmds/cmd_functions/data_checks.js
+++ b/cmds/cmd_functions/data_checks.js
@@ -73,12 +73,10 @@ module.exports = (tjmObject) => {
         if (tjmObject.l) {
             tjmObject.cluster = 'http://localhost:5678';
         }
-        if (_.isEmpty(clusters)) {
-            if (_.has(tjmObject.asset_file_content, 'tjm.clusters')) {
+        if (!_.has(tjmObject, 'cluster') && _.has(tjmObject.asset_file_content, 'tjm.clusters')) {
                 tjmObject.clusters = tjmObject.asset_file_content.tjm.clusters
-            }
         }
-        if (_.isEmpty(clusters) && !_.has(tjmObject, 'cluster')) {
+        if (_.isEmpty(tjmObject.clusters) && !_.has(tjmObject, 'cluster')) {
             reply.fatal('Cluster data is missing from asset.json or not specified using -c.');
         }
     }

--- a/cmds/cmd_functions/data_checks.js
+++ b/cmds/cmd_functions/data_checks.js
@@ -4,27 +4,27 @@ const _ = require('lodash');
 const path = require('path');
 const reply = require('./reply')();
 
-module.exports = (tjmObject) => {
+module.exports = (tjmConfig) => {
     function returnJobData(noTjmCheck) {
         // some commands should not have tjm data, otherwise file is checked for tjm data
-        tjmObject.tjm_check = !noTjmCheck;
-        // add job data to the tjmObject object for easy reference
+        tjmConfig.tjm_check = !noTjmCheck;
+        // add job data to the tjmConfig object for easy reference
         jobFileHandler();
         // explicitly state the cluster that the code will reference for the job
-        if (_.has(tjmObject.job_file_content, 'tjm.cluster')) {
-            tjmObject.cluster = tjmObject.job_file_content.tjm.cluster;
+        if (_.has(tjmConfig.job_file_content, 'tjm.cluster')) {
+            tjmConfig.cluster = tjmConfig.job_file_content.tjm.cluster;
             return;
         }
         
-        tjmObject.cluster = tjmObject.l ? 'http://localhost:5678' : tjmObject.c;
+        tjmConfig.cluster = tjmConfig.l ? 'http://localhost:5678' : tjmConfig.c;
 
-        if(!tjmObject.cluster) {
+        if(!tjmConfig.cluster) {
             reply.fatal('Use -c to specify a cluster or use -l for localhost')
         }
     }
 
     function jobFileHandler() {
-        let fName = tjmObject.job_file;
+        let fName = tjmConfig.job_file;
 
         if (!fName) {
             reply.fatal('Missing the job file!');
@@ -47,10 +47,10 @@ module.exports = (tjmObject) => {
             reply.fatal('JSON file contents cannot be empty');
         }
 
-        if (tjmObject.tjm_check === true) _tjmDataCheck(jobContents);
+        if (tjmConfig.tjm_check === true) _tjmDataCheck(jobContents);
 
-        tjmObject.job_file_path = jobFilePath;
-        tjmObject.job_file_content = jobContents;
+        tjmConfig.job_file_path = jobFilePath;
+        tjmConfig.job_file_content = jobContents;
     }
 
     function _tjmDataCheck(jsonData) {
@@ -66,17 +66,17 @@ module.exports = (tjmObject) => {
     }
 
     function getAssetClusters() {
-        if (tjmObject.c) {
-            const cluster = _urlCheck(tjmObject.c);
-            tjmObject.cluster = cluster;
+        if (tjmConfig.c) {
+            const cluster = _urlCheck(tjmConfig.c);
+            tjmConfig.cluster = cluster;
         }
-        if (tjmObject.l) {
-            tjmObject.cluster = 'http://localhost:5678';
+        if (tjmConfig.l) {
+            tjmConfig.cluster = 'http://localhost:5678';
         }
-        if (!_.has(tjmObject, 'cluster') && _.has(tjmObject.asset_file_content, 'tjm.clusters')) {
-                tjmObject.clusters = tjmObject.asset_file_content.tjm.clusters
+        if (!_.has(tjmConfig, 'cluster') && _.has(tjmConfig.asset_file_content, 'tjm.clusters')) {
+                tjmConfig.clusters = tjmConfig.asset_file_content.tjm.clusters
         }
-        if (_.isEmpty(tjmObject.clusters) && !_.has(tjmObject, 'cluster')) {
+        if (_.isEmpty(tjmConfig.clusters) && !_.has(tjmConfig, 'cluster')) {
             reply.fatal('Cluster data is missing from asset.json or not specified using -c.');
         }
     }

--- a/cmds/cmd_functions/data_checks.js
+++ b/cmds/cmd_functions/data_checks.js
@@ -7,24 +7,24 @@ const reply = require('./reply')();
 module.exports = (tjmObject) => {
     function returnJobData(noTjmCheck) {
         // some commands should not have tjm data, otherwise file is checked for tjm data
-        argv.tjm_check = !noTjmCheck;
-        // add job data to the argv object for easy reference
+        tjmObject.tjm_check = !noTjmCheck;
+        // add job data to the tjmObject object for easy reference
         jobFileHandler();
         // explicitly state the cluster that the code will reference for the job
-        if (_.has(argv.job_file_content, 'tjm.cluster')) {
-            argv.cluster = argv.job_file_content.tjm.cluster;
+        if (_.has(tjmObject.job_file_content, 'tjm.cluster')) {
+            tjmObject.cluster = tjmObject.job_file_content.tjm.cluster;
             return;
         }
         
-        argv.cluster = argv.l ? 'http://localhost:5678' : argv.c;
+        tjmObject.cluster = tjmObject.l ? 'http://localhost:5678' : tjmObject.c;
 
-        if(!argv.cluster) {
+        if(!tjmObject.cluster) {
             reply.fatal('Use -c to specify a cluster or use -l for localhost')
         }
     }
 
     function jobFileHandler() {
-        let fName = argv.job_file;
+        let fName = tjmObject.job_file;
 
         if (!fName) {
             reply.fatal('Missing the job file!');
@@ -47,10 +47,10 @@ module.exports = (tjmObject) => {
             reply.fatal('JSON file contents cannot be empty');
         }
 
-        if (argv.tjm_check === true) _tjmDataCheck(jobContents);
+        if (tjmObject.tjm_check === true) _tjmDataCheck(jobContents);
 
-        argv.job_file_path = jobFilePath;
-        argv.job_file_content = jobContents;
+        tjmObject.job_file_path = jobFilePath;
+        tjmObject.job_file_content = jobContents;
     }
 
     function _tjmDataCheck(jsonData) {

--- a/cmds/cmd_functions/data_checks.js
+++ b/cmds/cmd_functions/data_checks.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const path = require('path');
 const reply = require('./reply')();
 
-module.exports = (argv) => {
+module.exports = (tjmObject) => {
     function returnJobData(noTjmCheck) {
         // some commands should not have tjm data, otherwise file is checked for tjm data
         argv.tjm_check = !noTjmCheck;
@@ -60,9 +60,33 @@ module.exports = (argv) => {
         return true;
     }
 
+    function _urlCheck(url) {
+        // check that url starts with http:// but allow for https://
+        return url.indexOf('http') === -1 ? `http://${url}`: url;
+    }
+
+    function getAssetClusters() {
+        if (tjmObject.c) {
+            const cluster = _urlCheck(tjmObject.c);
+            tjmObject.cluster = cluster;
+        }
+        if (tjmObject.l) {
+            tjmObject.cluster = 'http://localhost:5678';
+        }
+        if (_.isEmpty(clusters)) {
+            if (_.has(tjmObject.asset_file_content, 'tjm.clusters')) {
+                tjmObject.clusters = tjmObject.asset_file_content.tjm.clusters
+            }
+        }
+        if (_.isEmpty(clusters) && !_.has(tjmObject, 'cluster')) {
+            reply.fatal('Cluster data is missing from asset.json or not specified using -c.');
+        }
+    }
     return {
         returnJobData,
         jobFileHandler,
+        getAssetClusters,
+        _urlCheck,
         _tjmDataCheck
     };
 };

--- a/cmds/cmd_functions/functions.js
+++ b/cmds/cmd_functions/functions.js
@@ -7,13 +7,13 @@ const Promise = require('bluebird');
 const reply = require('./reply')();
 const path = require('path');
 
-module.exports = (argv) => {
+module.exports = (tjmObject) => {
     let teraslice = require('teraslice-client-js')({
-        host: `${argv.cluster}`
+        host: `${tjmObject.cluster}`
     });
 
     function alreadyRegisteredCheck() {
-        const jobContents = argv.job_file_content;
+        const jobContents = tjmObject.job_file_content;
         if (_.has(jobContents, 'tjm.cluster')) {
             return teraslice.jobs.wrap(jobContents.tjm.job_id).spec()
                 .then((jobSpec) => {
@@ -35,7 +35,7 @@ module.exports = (argv) => {
     }
 
     function loadAsset() {
-        if (!argv.a) {
+        if (!tjmObject.a) {
             return Promise.resolve();
         }
         return fs.emptyDir(path.join(process.cwd(), 'builds'))
@@ -50,7 +50,7 @@ module.exports = (argv) => {
                 if (postResponseJson.error) {
                     return Promise.reject(new Error(postResponseJson.error));
                 }
-                reply.green(`Asset posted to ${argv.c} with id ${postResponseJson._id}`);
+                reply.green(`Asset posted to ${tjmObject.c} with id ${postResponseJson._id}`);
                 return Promise.resolve();
             })
             .then(() => {
@@ -58,7 +58,7 @@ module.exports = (argv) => {
                 return createJsonFile(path.join(process.cwd(), 'asset/asset.json'), assetJson);
             })
             .then(() => reply.green('TJM data added to asset.json'))
-            .then(() => reply.green(`Asset has successfully been deployed to ${argv.c}`));
+            .then(() => reply.green(`Asset has successfully been deployed to ${tjmObject.c}`));
     }
 
     function createJsonFile(filePath, jsonObject) {
@@ -101,7 +101,7 @@ module.exports = (argv) => {
             throw new Error(`Could not load asset.json: ${err.message}`);
         }
 
-        const cluster = argv.l ? 'http://localhost:5678' : argv.c;
+        const cluster = tjmObject.l ? 'http://localhost:5678' : tjmObject.c;
         if (_.has(assetJson, 'tjm.clusters')) {
             if (_.indexOf(assetJson.tjm.clusters, cluster) >= 0) {
                 throw new Error(`Assets have already been deployed to ${cluster}, use update`);

--- a/cmds/cmd_functions/functions.js
+++ b/cmds/cmd_functions/functions.js
@@ -7,13 +7,13 @@ const Promise = require('bluebird');
 const reply = require('./reply')();
 const path = require('path');
 
-module.exports = (tjmObject) => {
+module.exports = (tjmConfig) => {
     let teraslice = require('teraslice-client-js')({
-        host: `${tjmObject.cluster}`
+        host: `${tjmConfig.cluster}`
     });
 
     function alreadyRegisteredCheck() {
-        const jobContents = tjmObject.job_file_content;
+        const jobContents = tjmConfig.job_file_content;
         if (_.has(jobContents, 'tjm.cluster')) {
             return teraslice.jobs.wrap(jobContents.tjm.job_id).spec()
                 .then((jobSpec) => {
@@ -35,7 +35,7 @@ module.exports = (tjmObject) => {
     }
 
     function loadAsset() {
-        if (!tjmObject.a) {
+        if (!tjmConfig.a) {
             return Promise.resolve();
         }
         return fs.emptyDir(path.join(process.cwd(), 'builds'))
@@ -50,7 +50,7 @@ module.exports = (tjmObject) => {
                 if (postResponseJson.error) {
                     return Promise.reject(new Error(postResponseJson.error));
                 }
-                reply.green(`Asset posted to ${tjmObject.c} with id ${postResponseJson._id}`);
+                reply.green(`Asset posted to ${tjmConfig.c} with id ${postResponseJson._id}`);
                 return Promise.resolve();
             })
             .then(() => {
@@ -58,7 +58,7 @@ module.exports = (tjmObject) => {
                 return createJsonFile(path.join(process.cwd(), 'asset/asset.json'), assetJson);
             })
             .then(() => reply.green('TJM data added to asset.json'))
-            .then(() => reply.green(`Asset has successfully been deployed to ${tjmObject.c}`));
+            .then(() => reply.green(`Asset has successfully been deployed to ${tjmConfig.c}`));
     }
 
     function createJsonFile(filePath, jsonObject) {
@@ -101,7 +101,7 @@ module.exports = (tjmObject) => {
             throw new Error(`Could not load asset.json: ${err.message}`);
         }
 
-        const cluster = tjmObject.l ? 'http://localhost:5678' : tjmObject.c;
+        const cluster = tjmConfig.l ? 'http://localhost:5678' : tjmConfig.c;
         if (_.has(assetJson, 'tjm.clusters')) {
             if (_.indexOf(assetJson.tjm.clusters, cluster) >= 0) {
                 throw new Error(`Assets have already been deployed to ${cluster}, use update`);

--- a/cmds/cmd_functions/functions.js
+++ b/cmds/cmd_functions/functions.js
@@ -7,26 +7,19 @@ const Promise = require('bluebird');
 const reply = require('./reply')();
 const path = require('path');
 
-module.exports = (argv, clusterName) => {
-    let cluster;
-    if (clusterName) {
-        cluster = clusterName;
-    } else if (argv.c) {
-        cluster = argv.c;
-    } else if (argv.l) {
-        cluster = 'http://localhost:5678';
-    }
-    httpClusterNameCheck(cluster);
+module.exports = (argv) => {
     let teraslice = require('teraslice-client-js')({
-        host: `${httpClusterNameCheck(cluster)}`
+        host: `${argv.cluster}`
     });
 
-    function alreadyRegisteredCheck(jobContents) {
+    function alreadyRegisteredCheck() {
+        const jobContents = argv.job_file_content;
         if (_.has(jobContents, 'tjm.cluster')) {
             return teraslice.jobs.wrap(jobContents.tjm.job_id).spec()
                 .then((jobSpec) => {
                     if (jobSpec.job_id === jobContents.tjm.job_id) {
-                        return Promise.resolve();
+                        // return true for testing purposes
+                        return Promise.resolve(true);
                     }
                     return Promise.reject(new Error('Job is not on the cluster'));
                 });
@@ -72,21 +65,6 @@ module.exports = (argv, clusterName) => {
         return fs.writeJson(filePath, jsonObject, { spaces: 4 });
     }
 
-    function httpClusterNameCheck(url) {
-        if (!url) {
-            return '';
-        }
-        // needs to have a port number
-        if (url.lastIndexOf(':') !== url.length - 5) {
-            reply.fatal('Cluster names need to include a port number');
-        }
-
-        if (url.indexOf('http') !== 0) {
-            return `http://${url}`;
-        }
-        return url;
-    }
-
     function zipAsset() {
         const zipMessage = {};
 
@@ -123,15 +101,15 @@ module.exports = (argv, clusterName) => {
             throw new Error(`Could not load asset.json: ${err.message}`);
         }
 
-        const c = argv.l ? 'http://localhost:5678' : argv.c;
+        const cluster = argv.l ? 'http://localhost:5678' : argv.c;
         if (_.has(assetJson, 'tjm.clusters')) {
-            if (_.indexOf(assetJson.tjm.clusters, httpClusterNameCheck(c)) >= 0) {
-                throw new Error(`Assets have already been deployed to ${c}, use update`);
+            if (_.indexOf(assetJson.tjm.clusters, cluster) >= 0) {
+                throw new Error(`Assets have already been deployed to ${cluster}, use update`);
             }
-            assetJson.tjm.clusters.push(httpClusterNameCheck(c));
+            assetJson.tjm.clusters.push(cluster);
             return assetJson;
         }
-        _.set(assetJson, 'tjm.clusters', [httpClusterNameCheck(c)]);
+        _.set(assetJson, 'tjm.clusters', [cluster]);
         return assetJson;
     }
 
@@ -148,7 +126,6 @@ module.exports = (argv, clusterName) => {
 
     return {
         alreadyRegisteredCheck,
-        httpClusterNameCheck,
         loadAsset,
         createJsonFile,
         teraslice,

--- a/cmds/cmd_functions/reply.js
+++ b/cmds/cmd_functions/reply.js
@@ -9,6 +9,7 @@ module.exports = () => {
     function formatErr(err) {
         return _.toString(_.get(err, 'message', err));
     }
+
     function fatal(err) {
         if (process.env.TJM_TEST_MODE) {
             throw formatErr(err);

--- a/cmds/errors.js
+++ b/cmds/errors.js
@@ -1,19 +1,18 @@
 'use strict';
 
-exports.command = 'errors <jobFile>';
+exports.command = 'errors <job_file>';
 exports.desc = 'Shows the errors for a job\n';
 exports.builder = (yargs) => {
     yargs.example('tjm errors jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
-    const jobId = jobContents.tjm.job_id;
+    require('./cmd_functions/json_data_functions')(argv).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    const jobId = argv.job_file_content.tjm.job_id;
+
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).errors())
         .then((errors) => {
             if (errors.length === 0) {

--- a/cmds/errors.js
+++ b/cmds/errors.js
@@ -12,11 +12,11 @@ exports.builder = (yargs) => {
 };
 
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
 
-    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
 
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).errors())

--- a/cmds/errors.js
+++ b/cmds/errors.js
@@ -1,16 +1,22 @@
 'use strict';
 
+
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
+const _ = require('lodash');
+
 exports.command = 'errors <job_file>';
 exports.desc = 'Shows the errors for a job\n';
 exports.builder = (yargs) => {
     yargs.example('tjm errors jobfile.prod');
 };
-exports.handler = (argv, _testFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    const jobId = argv.job_file_content.tjm.job_id;
+exports.handler = (argv, _testFunctions) => {
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+
+    const jobId = tjmObject.job_file_content.tjm.job_id;
 
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).errors())

--- a/cmds/pause.js
+++ b/cmds/pause.js
@@ -11,13 +11,13 @@ exports.builder = (yargs) => {
     yargs.example('tjm pause jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();
     // teraslice client functions or test functions
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
 
-    const jobId = tjmObject.job_file_content.tjm.job_id;
-    const cluster = tjmObject.cluster;
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
+    const cluster = tjmConfig.cluster;
 
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())

--- a/cmds/pause.js
+++ b/cmds/pause.js
@@ -1,18 +1,23 @@
 'use strict';
 
+
+const _ = require('lodash');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
+
 exports.command = 'pause <job_file>';
 exports.desc = 'pauses job on the specified cluster\n';
 exports.builder = (yargs) => {
     yargs.example('tjm pause jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData()
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();
     // teraslice client functions or test functions
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
 
-    const jobId = argv.job_file_content.tjm.job_id;
-    const cluster = argv.cluster;
+    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const cluster = tjmObject.cluster;
 
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())

--- a/cmds/pause.js
+++ b/cmds/pause.js
@@ -1,23 +1,20 @@
 'use strict';
 
-exports.command = 'pause <jobFile>';
+exports.command = 'pause <job_file>';
 exports.desc = 'pauses job on the specified cluster\n';
 exports.builder = (yargs) => {
     yargs.example('tjm pause jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    // job related data needed execute command
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const jobId = jobContents.tjm.job_id;
-    const cluster = jobContents.tjm.cluster;
+    require('./cmd_functions/json_data_functions')(argv).returnJobData()
     // teraslice client functions or test functions
-    const tjmFunctions = _testFunctions ||
-        require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    const jobId = argv.job_file_content.tjm.job_id;
+    const cluster = argv.cluster;
+
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())
         .then((jobStatus) => {
             if (jobStatus !== 'running') {

--- a/cmds/register.js
+++ b/cmds/register.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash');
 const Promise = require('bluebird');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
 
 exports.command = 'register [job_file]';
 exports.desc = 'Registers job with a cluster.  Specify the cluster with -c.\nAdds metadata to job file on completion\n';
@@ -24,31 +26,31 @@ exports.builder = (yargs) => {
         .example('tjm register jobfile.prod -c clusterDomain -a');
 };
 exports.handler = (argv, _testTjmFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData(true);
-    const tjmFunctions = _testTjmFunctions || require('./cmd_functions/functions')(argv);
-    const jobContents = argv.job_file_content;
-    const jobFilePath = argv.job_file_path;
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData(true);
+    const tjmFunctions = _testTjmFunctions || require('./cmd_functions/functions')(tjmObject);
+    const jobContents = tjmObject.job_file_content;
+    const jobFilePath = tjmObject.job_file_path;
 
     return tjmFunctions.loadAsset()
         .then(() => {
             if (!_.has(jobContents, 'tjm.cluster')) {
-                return tjmFunctions.teraslice.jobs.submit(jobContents, !argv.r);
+                return tjmFunctions.teraslice.jobs.submit(jobContents, !tjmObject.r);
             }
-            return Promise.reject(new Error(`Job is already registered on ${argv.cluster}`))
+            return Promise.reject(new Error(`Job is already registered on ${tjmObject.cluster}`))
         })
         .then((result) => {
             const jobId = result.id();
-            reply.green(`Successfully registered job: ${jobId} on ${argv.cluster}`);
-            _.set(jobContents, 'tjm.cluster', argv.cluster);
+            reply.green(`Successfully registered job: ${jobId} on ${tjmObject.cluster}`);
+            _.set(jobContents, 'tjm.cluster', tjmObject.cluster);
             _.set(jobContents, 'tjm.version', '0.0.1');
             _.set(jobContents, 'tjm.job_id', jobId);
             tjmFunctions.createJsonFile(jobFilePath, jobContents);
             reply.green('Updated job file with tjm data');
         })
         .then(() => {
-            if (argv.r) {
-                reply.green(`New job started on ${argv.cluster}`);
+            if (tjmObject.r) {
+                reply.green(`New job started on ${tjmObject.cluster}`);
             }
         })
         .catch(err => reply.fatal(err));

--- a/cmds/register.js
+++ b/cmds/register.js
@@ -26,31 +26,31 @@ exports.builder = (yargs) => {
         .example('tjm register jobfile.prod -c clusterDomain -a');
 };
 exports.handler = (argv, _testTjmFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData(true);
-    const tjmFunctions = _testTjmFunctions || require('./cmd_functions/functions')(tjmObject);
-    const jobContents = tjmObject.job_file_content;
-    const jobFilePath = tjmObject.job_file_path;
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData(true);
+    const tjmFunctions = _testTjmFunctions || require('./cmd_functions/functions')(tjmConfig);
+    const jobContents = tjmConfig.job_file_content;
+    const jobFilePath = tjmConfig.job_file_path;
 
     return tjmFunctions.loadAsset()
         .then(() => {
             if (!_.has(jobContents, 'tjm.cluster')) {
-                return tjmFunctions.teraslice.jobs.submit(jobContents, !tjmObject.r);
+                return tjmFunctions.teraslice.jobs.submit(jobContents, !tjmConfig.r);
             }
-            return Promise.reject(new Error(`Job is already registered on ${tjmObject.cluster}`))
+            return Promise.reject(new Error(`Job is already registered on ${tjmConfig.cluster}`))
         })
         .then((result) => {
             const jobId = result.id();
-            reply.green(`Successfully registered job: ${jobId} on ${tjmObject.cluster}`);
-            _.set(jobContents, 'tjm.cluster', tjmObject.cluster);
+            reply.green(`Successfully registered job: ${jobId} on ${tjmConfig.cluster}`);
+            _.set(jobContents, 'tjm.cluster', tjmConfig.cluster);
             _.set(jobContents, 'tjm.version', '0.0.1');
             _.set(jobContents, 'tjm.job_id', jobId);
             tjmFunctions.createJsonFile(jobFilePath, jobContents);
             reply.green('Updated job file with tjm data');
         })
         .then(() => {
-            if (tjmObject.r) {
-                reply.green(`New job started on ${tjmObject.cluster}`);
+            if (tjmConfig.r) {
+                reply.green(`New job started on ${tjmConfig.cluster}`);
             }
         })
         .catch(err => reply.fatal(err));

--- a/cmds/reset.js
+++ b/cmds/reset.js
@@ -13,10 +13,10 @@ exports.builder = (yargs) => {
     yargs.example('tjm reset jobfile.prod');
 };
 exports.handler = (argv) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData(true);
-    delete tjmObject.job_file_content.tjm;
-    return fs.writeJson(tjmObject.job_file_path, tjmObject.job_file_content, { spaces: 4 })
-        .then(() => reply.green(`TJM data was removed from ${tjmObject.job_file}`))
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData(true);
+    delete tjmConfig.job_file_content.tjm;
+    return fs.writeJson(tjmConfig.job_file_path, tjmConfig.job_file_content, { spaces: 4 })
+        .then(() => reply.green(`TJM data was removed from ${tjmConfig.job_file}`))
         .catch(err => reply.fatal(err.message));
 };

--- a/cmds/reset.js
+++ b/cmds/reset.js
@@ -3,20 +3,17 @@
 // removes tjm data from json file
 const fs = require('fs-extra');
 
-exports.command = 'reset [jobFile]';
+exports.command = 'reset [job_file]';
 exports.desc = 'Removes tjm data from job or asset file';
 exports.builder = (yargs) => {
     yargs.example('tjm reset jobfile.prod');
 };
 exports.handler = (argv) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobData = jsonData.jobFileHandler(argv.jobFile);
-    const jobContents = jobData[1];
-    const jobFilePath = jobData[0];
+    require('./cmd_functions/json_data_functions')(argv).returnJobData(true);
 
-    delete jobContents.tjm;
-    return fs.writeJson(jobFilePath, jobContents, { spaces: 4 })
-        .then(() => reply.green(`TJM data was removed from ${argv.jobFile}`))
+    delete argv.job_file_content.tjm;
+    return fs.writeJson(argv.job_file_path, argv.job_file_content, { spaces: 4 })
+        .then(() => reply.green(`TJM data was removed from ${argv.job_file}`))
         .catch(err => reply.fatal(err.message));
 };

--- a/cmds/reset.js
+++ b/cmds/reset.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const _ = require('lodash');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
+
 // removes tjm data from json file
 const fs = require('fs-extra');
 
@@ -9,11 +13,10 @@ exports.builder = (yargs) => {
     yargs.example('tjm reset jobfile.prod');
 };
 exports.handler = (argv) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData(true);
-
-    delete argv.job_file_content.tjm;
-    return fs.writeJson(argv.job_file_path, argv.job_file_content, { spaces: 4 })
-        .then(() => reply.green(`TJM data was removed from ${argv.job_file}`))
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData(true);
+    delete tjmObject.job_file_content.tjm;
+    return fs.writeJson(tjmObject.job_file_path, tjmObject.job_file_content, { spaces: 4 })
+        .then(() => reply.green(`TJM data was removed from ${tjmObject.job_file}`))
         .catch(err => reply.fatal(err.message));
 };

--- a/cmds/restart.js
+++ b/cmds/restart.js
@@ -10,10 +10,10 @@ exports.builder = (yargs) => {
     yargs.example('tjm restart jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
-    const jobContents = tjmObject.job_file_content;
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
+    const jobContents = tjmConfig.job_file_content;
     const jobId = jobContents.tjm.job_id;
 
     return tjmFunctions.alreadyRegisteredCheck()

--- a/cmds/restart.js
+++ b/cmds/restart.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
 
 exports.command = 'restart <job_file>';
 exports.desc = 'stops and starts a job\n';
@@ -8,10 +10,10 @@ exports.builder = (yargs) => {
     yargs.example('tjm restart jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
-    const jobContents = argv.job_file_content;
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const jobContents = tjmObject.job_file_content;
     const jobId = jobContents.tjm.job_id;
 
     return tjmFunctions.alreadyRegisteredCheck()

--- a/cmds/restart.js
+++ b/cmds/restart.js
@@ -2,20 +2,19 @@
 
 const _ = require('lodash');
 
-exports.command = 'restart <jobFile>';
+exports.command = 'restart <job_file>';
 exports.desc = 'stops and starts a job\n';
 exports.builder = (yargs) => {
     yargs.example('tjm restart jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
+    require('./cmd_functions/json_data_functions')(argv).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
+    const jobContents = argv.job_file_content;
     const jobId = jobContents.tjm.job_id;
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).stop())
         .then((stopResponse) => {
             if (!stopResponse.status.status === 'stopped') {

--- a/cmds/resume.js
+++ b/cmds/resume.js
@@ -1,20 +1,20 @@
 'use strict';
 
-exports.command = 'resume <jobFile>';
+exports.command = 'resume <job_file>';
 exports.desc = 'resumes a paused job\n';
 exports.builder = (yargs) => {
     yargs.example('tjm resume jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
-    const jobId = jobContents.tjm.job_id;
-    const cluster = jobContents.tjm.cluster;
+    // ensure that tjm data is in job file
+    require('./cmd_functions/json_data_functions')(argv).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    const jobId = argv.job_file_content.tjm.job_id;
+    const cluster = argv.cluster;
+
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())
         .then((status) => {
             if (status !== 'paused') {

--- a/cmds/resume.js
+++ b/cmds/resume.js
@@ -10,12 +10,12 @@ exports.builder = (yargs) => {
     yargs.example('tjm resume jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
 
-    const jobId = tjmObject.job_file_content.tjm.job_id;
-    const cluster = tjmObject.cluster;
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
+    const cluster = tjmConfig.cluster;
 
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())

--- a/cmds/resume.js
+++ b/cmds/resume.js
@@ -1,18 +1,21 @@
 'use strict';
 
+const _ = require('lodash');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
+
 exports.command = 'resume <job_file>';
 exports.desc = 'resumes a paused job\n';
 exports.builder = (yargs) => {
     yargs.example('tjm resume jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    // ensure that tjm data is in job file
-    require('./cmd_functions/json_data_functions')(argv).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
 
-    const jobId = argv.job_file_content.tjm.job_id;
-    const cluster = argv.cluster;
+    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const cluster = tjmObject.cluster;
 
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())

--- a/cmds/start.js
+++ b/cmds/start.js
@@ -10,11 +10,11 @@ exports.builder = (yargs) => {
     yargs.example('tjm start jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();    
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();    
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
 
-    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).start())
         .then((startResponse) => {

--- a/cmds/start.js
+++ b/cmds/start.js
@@ -2,20 +2,18 @@
 
 const _ = require('lodash');
 
-exports.command = 'start <jobFile>';
+exports.command = 'start <job_file>';
 exports.desc = 'Starts job on the cluster in the job file\n';
 exports.builder = (yargs) => {
     yargs.example('tjm start jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
-    const jobId = jobContents.tjm.job_id;
+    require('./cmd_functions/json_data_functions')(argv).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    const jobId = argv.job_file_content.tjm.job_id;
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).start())
         .then((startResponse) => {
             if (_.has(startResponse, 'job_id')) {

--- a/cmds/start.js
+++ b/cmds/start.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
 
 exports.command = 'start <job_file>';
 exports.desc = 'Starts job on the cluster in the job file\n';
@@ -8,11 +10,11 @@ exports.builder = (yargs) => {
     yargs.example('tjm start jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();    
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
 
-    const jobId = argv.job_file_content.tjm.job_id;
+    const jobId = tjmObject.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).start())
         .then((startResponse) => {

--- a/cmds/status.js
+++ b/cmds/status.js
@@ -1,19 +1,17 @@
 'use strict';
 
-exports.command = 'status <jobFile>';
+exports.command = 'status <job_file>';
 exports.desc = 'reports the job status\n';
 exports.builder = (yargs) => {
     yargs.example('tjm status jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
-    const jobId = jobContents.tjm.job_id;
+    require('./cmd_functions/json_data_functions')(argv).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    const jobId = argv.job_file_content.tjm.job_id;
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())
         .then((status) => {
             reply.green(`Job status: ${status}`);

--- a/cmds/status.js
+++ b/cmds/status.js
@@ -10,12 +10,12 @@ exports.builder = (yargs) => {
     yargs.example('tjm status jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();    
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();    
     
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
 
-    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())
         .then((status) => {

--- a/cmds/status.js
+++ b/cmds/status.js
@@ -1,16 +1,21 @@
 'use strict';
 
+const _ = require('lodash');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
+
 exports.command = 'status <job_file>';
 exports.desc = 'reports the job status\n';
 exports.builder = (yargs) => {
     yargs.example('tjm status jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();    
+    
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
 
-    const jobId = argv.job_file_content.tjm.job_id;
+    const jobId = tjmObject.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).status())
         .then((status) => {

--- a/cmds/stop.js
+++ b/cmds/stop.js
@@ -1,16 +1,20 @@
 'use strict';
 
+const _ = require('lodash');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
+
 exports.command = 'stop <job_file>';
 exports.desc = 'stops job on the cluster in the job file\n';
 exports.builder = (yargs) => {
     yargs.example('tjm stop jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
 
-    const jobId = argv.job_file_content.tjm.job_id;
+    const jobId = tjmObject.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).stop())
         .then((stopResponse) => {

--- a/cmds/stop.js
+++ b/cmds/stop.js
@@ -10,11 +10,11 @@ exports.builder = (yargs) => {
     yargs.example('tjm stop jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
 
-    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).stop())
         .then((stopResponse) => {

--- a/cmds/stop.js
+++ b/cmds/stop.js
@@ -1,25 +1,23 @@
 'use strict';
 
-exports.command = 'stop <jobFile>';
+exports.command = 'stop <job_file>';
 exports.desc = 'stops job on the cluster in the job file\n';
 exports.builder = (yargs) => {
     yargs.example('tjm stop jobfile.prod.json');
 };
 exports.handler = (argv, _testFunctions) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
-    const jobId = jobContents.tjm.job_id;
+    require('./cmd_functions/json_data_functions')(argv).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    const jobId = argv.job_file_content.tjm.job_id;
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).stop())
         .then((stopResponse) => {
             if (!stopResponse.status.status === 'stopped') {
                 return Promise.reject(new Error('Job could not be stopped'));                
             }
-            reply.green(`Stopped job ${jobId} on ${jobContents.tjm.cluster}`);
+            reply.green(`Stopped job ${jobId} on ${argv.cluster}`);
                 return stopResponse;
         })
         .catch(err => reply.fatal(err));

--- a/cmds/update.js
+++ b/cmds/update.js
@@ -16,12 +16,12 @@ exports.builder = (yargs) => {
         .example('tjm update jobfile.prod.json -r');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();
     
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
-    const jobId = tjmObject.job_file_content.tjm.job_id;
-    const cluster = tjmObject.cluster;
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
+    const cluster = tjmConfig.cluster;
 
     function restartJob() {
         return tjmFunctions.teraslice.jobs.wrap(jobId).status()
@@ -46,7 +46,7 @@ exports.handler = (argv, _testFunctions) => {
     }
 
     return tjmFunctions.alreadyRegisteredCheck()
-        .then(() => tjmFunctions.teraslice.cluster.put(`/jobs/${jobId}`, tjmObject.job_file_content))
+        .then(() => tjmFunctions.teraslice.cluster.put(`/jobs/${jobId}`, tjmConfig.job_file_content))
         .then((updateResponse) => {
             if (_.isEmpty(updateResponse)) {
                 return Promise.reject(new Error ('Could not update job'));
@@ -56,7 +56,7 @@ exports.handler = (argv, _testFunctions) => {
             return Promise.resolve();
         })
         .then(() => {
-            if (!tjmObject.r) {
+            if (!tjmConfig.r) {
                 return Promise.resolve();
             }
             return restartJob();

--- a/cmds/update.js
+++ b/cmds/update.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
+const reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
 
 exports.command = 'update [job_file]';
 exports.desc = 'Updates the job on the cluster listed in the job file\nUse -r to run or restart the job after the update\n';
@@ -14,12 +16,12 @@ exports.builder = (yargs) => {
         .example('tjm update jobfile.prod.json -r');
 };
 exports.handler = (argv, _testFunctions) => {
-    const reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData();
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
-
-    const jobId = argv.job_file_content.tjm.job_id;
-    const cluster = argv.cluster;
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();
+    
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const cluster = tjmObject.cluster;
 
     function restartJob() {
         return tjmFunctions.teraslice.jobs.wrap(jobId).status()
@@ -44,7 +46,7 @@ exports.handler = (argv, _testFunctions) => {
     }
 
     return tjmFunctions.alreadyRegisteredCheck()
-        .then(() => tjmFunctions.teraslice.cluster.put(`/jobs/${jobId}`, argv.job_file_content))
+        .then(() => tjmFunctions.teraslice.cluster.put(`/jobs/${jobId}`, tjmObject.job_file_content))
         .then((updateResponse) => {
             if (_.isEmpty(updateResponse)) {
                 return Promise.reject(new Error ('Could not update job'));
@@ -54,7 +56,7 @@ exports.handler = (argv, _testFunctions) => {
             return Promise.resolve();
         })
         .then(() => {
-            if (!argv.r) {
+            if (!tjmObject.r) {
                 return Promise.resolve();
             }
             return restartJob();

--- a/cmds/view.js
+++ b/cmds/view.js
@@ -1,25 +1,22 @@
 'use strict';
 
-exports.command = 'view [jobFile]';
+exports.command = 'view [job_file]';
 exports.desc = 'Displays the job file as saved on the cluster specified in the tjm data';
 exports.builder = (yargs) => {
     yargs.example('tjm view jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
     let reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const jobId = jobContents.tjm.job_id;
-    let tjmFunctions = _testFunctions ||
-        require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
+    require('./cmd_functions/json_data_functions')(argv).returnJobData();
+    let tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    const jobId = argv.job_file_content.tjm.job_id;
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).spec())
         .then(jobSpec => {
-            reply.yellow(`Current Job File on Cluster ${jobContents.tjm.cluster}:`);
+            reply.yellow(`Current Job File on Cluster ${argv.cluster}:`);
             reply.green(JSON.stringify(jobSpec, null, 4));
             return jobSpec;
         })
-        .catch(err => reply.fatal(err));
+        .catch(err => reply.fatal(err.stack));
 };

--- a/cmds/view.js
+++ b/cmds/view.js
@@ -10,15 +10,15 @@ exports.builder = (yargs) => {
     yargs.example('tjm view jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();
-    let tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();
+    let tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
 
-    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).spec())
         .then(jobSpec => {
-            reply.yellow(`Current Job File on Cluster ${tjmObject.cluster}:`);
+            reply.yellow(`Current Job File on Cluster ${tjmConfig.cluster}:`);
             reply.green(JSON.stringify(jobSpec, null, 4));
             return jobSpec;
         })

--- a/cmds/view.js
+++ b/cmds/view.js
@@ -1,20 +1,24 @@
 'use strict';
 
+const _ = require('lodash');
+let reply = require('./cmd_functions/reply')();
+const dataChecks = require('./cmd_functions/data_checks');
+
 exports.command = 'view [job_file]';
 exports.desc = 'Displays the job file as saved on the cluster specified in the tjm data';
 exports.builder = (yargs) => {
     yargs.example('tjm view jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    let reply = require('./cmd_functions/reply')();
-    require('./cmd_functions/json_data_functions')(argv).returnJobData();
-    let tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
+    const tjmObject = _.clone(argv);
+    dataChecks(tjmObject).returnJobData();
+    let tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
 
-    const jobId = argv.job_file_content.tjm.job_id;
+    const jobId = tjmObject.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => tjmFunctions.teraslice.jobs.wrap(jobId).spec())
         .then(jobSpec => {
-            reply.yellow(`Current Job File on Cluster ${argv.cluster}:`);
+            reply.yellow(`Current Job File on Cluster ${tjmObject.cluster}:`);
             reply.green(JSON.stringify(jobSpec, null, 4));
             return jobSpec;
         })

--- a/cmds/workers.js
+++ b/cmds/workers.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 
-exports.command = 'workers <param> <num> <jobFile>';
+exports.command = 'workers <param> <num> <job_file>';
 exports.desc = 'add or remove workers to a job';
 exports.builder = (yargs) => {
     yargs
@@ -11,13 +11,11 @@ exports.builder = (yargs) => {
 };
 exports.handler = (argv, _testFunctions) => {
     const reply = require('./cmd_functions/reply')();
-    const jsonData = require('./cmd_functions/json_data_functions')();
-    const jobContents = jsonData.jobFileHandler(argv.jobFile)[1];
-    jsonData.metaDataCheck(jobContents);
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv, jobContents.tjm.cluster);
-    const jobId = jobContents.tjm.job_id;
+    require('./cmd_functions/json_data_functions')(argv).returnJobData();
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(argv);
 
-    return tjmFunctions.alreadyRegisteredCheck(jobContents)
+    const jobId = argv.job_file_content.tjm.job_id;
+    return tjmFunctions.alreadyRegisteredCheck()
         .then(() => {
             if (argv.num <= 0 || _.isNaN(argv.num)) {
                 return Promise.reject(new Error('Number of workers must be a positive number greater'));

--- a/cmds/workers.js
+++ b/cmds/workers.js
@@ -12,19 +12,19 @@ exports.builder = (yargs) => {
         .example('tjm workers add 5 jobfile.prod');
 };
 exports.handler = (argv, _testFunctions) => {
-    const tjmObject = _.clone(argv);
-    dataChecks(tjmObject).returnJobData();
+    const tjmConfig = _.clone(argv);
+    dataChecks(tjmConfig).returnJobData();
     
-    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmObject);
+    const tjmFunctions = _testFunctions || require('./cmd_functions/functions')(tjmConfig);
 
-    const jobId = tjmObject.job_file_content.tjm.job_id;
+    const jobId = tjmConfig.job_file_content.tjm.job_id;
     return tjmFunctions.alreadyRegisteredCheck()
         .then(() => {
             if (argv.num <= 0 || _.isNaN(argv.num)) {
                 return Promise.reject(new Error('Number of workers must be a positive number'));
             }
             return tjmFunctions.teraslice.jobs.wrap(jobId)
-                .changeWorkers(tjmObject.param, tjmObject.num);
+                .changeWorkers(tjmConfig.param, tjmConfig.num);
         })
         .then((workersChange) => {
             reply.green(workersChange);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teraslice-job-manager",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "teraslice job manager",
   "main": "index.js",
   "publishConfig": {

--- a/spec/asset-spec.js
+++ b/spec/asset-spec.js
@@ -45,7 +45,7 @@ describe('asset command testing', () => {
             .then(() => asset.handler(argv, _tjmFunctions))
             .then((result) => {
                 expect(result).toEqual('deployed');
-            });
+            })
     });
 
     it('deploy should respond to a request error', () => {

--- a/spec/asset-spec.js
+++ b/spec/asset-spec.js
@@ -58,7 +58,7 @@ describe('asset command testing', () => {
         deployError = error;
         return asset.handler(argv, _tjmFunctions)
             .catch((err) => {
-                expect(err).toBe('Could not connect to localhost:5678');
+                expect(err).toBe('Could not connect to http://localhost:5678');
             });
     });
 

--- a/spec/data_check-spec.js
+++ b/spec/data_check-spec.js
@@ -14,32 +14,32 @@ describe('checks to for job and asset file content', () => {
             JSON.stringify({ test: 'test' })
         );
 
-        const tjmObject = {
+        const tjmConfig = {
             job_file: 'tfile.prod.json',
             tjm_check: false
         }
 
-        let jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        let jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
         let jobData = jobFileFunctions.jobFileHandler();
-        expect(tjmObject.job_file_content.test).toBe('test');
+        expect(tjmConfig.job_file_content.test).toBe('test');
 
-        jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
         jobData = jobFileFunctions.jobFileHandler();
-        expect(tjmObject.job_file_content.test).toBe('test');
+        expect(tjmConfig.job_file_content.test).toBe('test');
         fs.unlinkSync(path.join(__dirname, '..', 'tfile.prod.json'));
     });
 
     it('missing job file throws error', () => {
-        const tjmObject = {};
-        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        const tjmConfig = {};
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
         expect(jobFileFunctions.jobFileHandler).toThrow('Missing the job file!');
     });
 
     it('bad file path throws an error', () => {
-        const tjmObject = {
+        const tjmConfig = {
             job_file: 'jobTest.json'
         };
-        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
         expect(jobFileFunctions.jobFileHandler)
             .toThrow('Sorry, can\'t find the JSON file: jobTest.json');
     });
@@ -54,11 +54,11 @@ describe('checks to for job and asset file content', () => {
             JSON.stringify({ })
             );
 
-        const tjmObject = {
+        const tjmConfig = {
             job_file: 'testFile.json'
         }
 
-        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
         expect(jobFileFunctions.jobFileHandler)
             .toThrow('JSON file contents cannot be empty');
         fs.unlinkSync(path.join(__dirname, '..', 'testFile.json'));
@@ -76,9 +76,9 @@ describe('checks to for job and asset file content', () => {
             clusters: ['http://localhost', 'http://cluster2']
         };
 
-        const tjmObject = {};
+        const tjmConfig = {};
 
-        let jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        let jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
         expect(jobFileFunctions._tjmDataCheck(jsonFileData)).toBe(true);
         delete jsonFileData.tjm;
 
@@ -102,15 +102,15 @@ describe('checks to for job and asset file content', () => {
             JSON.stringify({ test: 'test' })
         );
 
-        const tjmObject = {
+        const tjmConfig = {
             job_file: 'tfile.prod.json',
             l: true
         };
 
-        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
 
         const jobData = jobFileFunctions.returnJobData(true);
-        expect(tjmObject.cluster).toBe('http://localhost:5678');
+        expect(tjmConfig.cluster).toBe('http://localhost:5678');
         fs.unlinkSync(path.join(__dirname, '..', 'tfile.prod.json'));
     });
 
@@ -127,14 +127,14 @@ describe('checks to for job and asset file content', () => {
             })
         );
 
-        const tjmObject = {
+        const tjmConfig = {
             job_file: 'fakeFile.json',
             tjm_check: true
         };
 
-        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
         const jobData = jobFileFunctions.returnJobData();
-        expect(tjmObject.cluster).toBe('aclustername');
+        expect(tjmConfig.cluster).toBe('aclustername');
         fs.unlinkSync(path.join(__dirname, '..', 'fakeFile.json'));
     });
 
@@ -147,14 +147,14 @@ describe('checks to for job and asset file content', () => {
             })
         );
 
-        const tjmObject = {
+        const tjmConfig = {
             job_file: 'fakeFile2.json',
             c: 'someClusterName'
         };
 
-        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmConfig);
         const jobData = jobFileFunctions.returnJobData(true);
-        expect(tjmObject.cluster).toBe('someClusterName');
+        expect(tjmConfig.cluster).toBe('someClusterName');
         fs.unlinkSync(path.join(__dirname, '..', 'fakeFile2.json'));
     });
 });

--- a/spec/data_check-spec.js
+++ b/spec/data_check-spec.js
@@ -3,7 +3,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-describe('jsonDataFunctions', () => {
+describe('checks to for job and asset file content', () => {
     it('job files do not have to end in json', () => {
         fs.writeFileSync(
             path.join(
@@ -14,32 +14,32 @@ describe('jsonDataFunctions', () => {
             JSON.stringify({ test: 'test' })
         );
 
-        const argv = {
+        const tjmObject = {
             job_file: 'tfile.prod.json',
             tjm_check: false
         }
 
-        let jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        let jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
         let jobData = jobFileFunctions.jobFileHandler();
-        expect(argv.job_file_content.test).toBe('test');
+        expect(tjmObject.job_file_content.test).toBe('test');
 
-        jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
         jobData = jobFileFunctions.jobFileHandler();
-        expect(argv.job_file_content.test).toBe('test');
+        expect(tjmObject.job_file_content.test).toBe('test');
         fs.unlinkSync(path.join(__dirname, '..', 'tfile.prod.json'));
     });
 
     it('missing job file throws error', () => {
-        const argv = {};
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        const tjmObject = {};
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
         expect(jobFileFunctions.jobFileHandler).toThrow('Missing the job file!');
     });
 
     it('bad file path throws an error', () => {
-        const argv = {
+        const tjmObject = {
             job_file: 'jobTest.json'
         };
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
         expect(jobFileFunctions.jobFileHandler)
             .toThrow('Sorry, can\'t find the JSON file: jobTest.json');
     });
@@ -54,11 +54,11 @@ describe('jsonDataFunctions', () => {
             JSON.stringify({ })
             );
 
-        const argv = {
+        const tjmObject = {
             job_file: 'testFile.json'
         }
 
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
         expect(jobFileFunctions.jobFileHandler)
             .toThrow('JSON file contents cannot be empty');
         fs.unlinkSync(path.join(__dirname, '..', 'testFile.json'));
@@ -76,9 +76,9 @@ describe('jsonDataFunctions', () => {
             clusters: ['http://localhost', 'http://cluster2']
         };
 
-        const argv = {};
+        const tjmObject = {};
 
-        let jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        let jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
         expect(jobFileFunctions._tjmDataCheck(jsonFileData)).toBe(true);
         delete jsonFileData.tjm;
 
@@ -90,7 +90,7 @@ describe('jsonDataFunctions', () => {
 
         // test no metadata
         delete jsonFileData.tjm;
-        jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
+        jobFileFunctions = require('../cmds/cmd_functions/data_checks')();
         expect(jobFileFunctions._tjmDataCheck).toThrow('No teraslice job manager metadata, register the job or deploy the assets');
     });
 
@@ -102,15 +102,15 @@ describe('jsonDataFunctions', () => {
             JSON.stringify({ test: 'test' })
         );
 
-        const argv = {
+        const tjmObject = {
             job_file: 'tfile.prod.json',
             l: true
         };
 
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
 
         const jobData = jobFileFunctions.returnJobData(true);
-        expect(argv.cluster).toBe('http://localhost:5678');
+        expect(tjmObject.cluster).toBe('http://localhost:5678');
         fs.unlinkSync(path.join(__dirname, '..', 'tfile.prod.json'));
     });
 
@@ -127,14 +127,14 @@ describe('jsonDataFunctions', () => {
             })
         );
 
-        const argv = {
+        const tjmObject = {
             job_file: 'fakeFile.json',
             tjm_check: true
         };
 
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
         const jobData = jobFileFunctions.returnJobData();
-        expect(argv.cluster).toBe('aclustername');
+        expect(tjmObject.cluster).toBe('aclustername');
         fs.unlinkSync(path.join(__dirname, '..', 'fakeFile.json'));
     });
 
@@ -147,14 +147,14 @@ describe('jsonDataFunctions', () => {
             })
         );
 
-        const argv = {
+        const tjmObject = {
             job_file: 'fakeFile2.json',
             c: 'someClusterName'
         };
 
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        const jobFileFunctions = require('../cmds/cmd_functions/data_checks')(tjmObject);
         const jobData = jobFileFunctions.returnJobData(true);
-        expect(argv.cluster).toBe('someClusterName');
+        expect(tjmObject.cluster).toBe('someClusterName');
         fs.unlinkSync(path.join(__dirname, '..', 'fakeFile2.json'));
     });
 });

--- a/spec/errors-spec.js
+++ b/spec/errors-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const errors = require('../cmds/errors');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;

--- a/spec/jsonDataFunctions-spec.js
+++ b/spec/jsonDataFunctions-spec.js
@@ -3,46 +3,68 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-describe('tests jsonDataFunctions', () => {
+describe('jsonDataFunctions', () => {
     it('job files do not have to end in json', () => {
-        fs.writeFileSync(path.join(__dirname, '..', 'tfile.prod.json'), JSON.stringify({ test: 'test' }));
-        let jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
-        let jobData = jobFileFunctions.jobFileHandler('tfile.prod.json');
-        expect((jobData[1]).test).toBe('test');
+        fs.writeFileSync(
+            path.join(
+                __dirname,
+                '..',
+                'tfile.prod.json'
+            ),
+            JSON.stringify({ test: 'test' })
+        );
 
-        jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
-        jobData = jobFileFunctions.jobFileHandler('tfile.prod');
-        expect((jobData[1]).test).toBe('test');
+        const argv = {
+            job_file: 'tfile.prod.json',
+            tjm_check: false
+        }
+
+        let jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        let jobData = jobFileFunctions.jobFileHandler();
+        expect(argv.job_file_content.test).toBe('test');
+
+        jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        jobData = jobFileFunctions.jobFileHandler();
+        expect(argv.job_file_content.test).toBe('test');
         fs.unlinkSync(path.join(__dirname, '..', 'tfile.prod.json'));
     });
 
-    it('no job file throws error', () => {
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
+    it('missing job file throws error', () => {
+        const argv = {};
+        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
         expect(jobFileFunctions.jobFileHandler).toThrow('Missing the job file!');
     });
 
-    it('path should change to asset/jsonFile if true as second function input', () => {
-        fs.emptyDirSync(path.join(__dirname, '..', 'asset'));
-        fs.writeFileSync(path.join(__dirname, '..', 'asset/assetTest.json'), JSON.stringify({ test: 'test' }));
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
-        const returnData = jobFileFunctions.jobFileHandler('assetTest.json', true);
-        expect(returnData[0]).toBe(path.join(__dirname, '..', 'asset/assetTest.json'));
-        expect(returnData[1].test).toBe('test');
-    });
-
     it('bad file path throws an error', () => {
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
-        expect(() => { jobFileFunctions.jobFileHandler('jobTest.json'); }).toThrow('Sorry, can\'t find the JSON file: jobTest.json');
+        const argv = {
+            job_file: 'jobTest.json'
+        };
+        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        expect(jobFileFunctions.jobFileHandler)
+            .toThrow('Sorry, can\'t find the JSON file: jobTest.json');
     });
 
     it('empty json file throws an error', () => {
-        fs.writeFileSync(path.join(__dirname, '..', 'testFile.json'), JSON.stringify({ }));
-        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
-        expect(() => { jobFileFunctions.jobFileHandler('testFile.json'); }).toThrow('JSON file contents cannot be empty');
+        fs.writeFileSync(
+            path.join(
+                __dirname,
+                '..',
+                'testFile.json'
+            ),
+            JSON.stringify({ })
+            );
+
+        const argv = {
+            job_file: 'testFile.json'
+        }
+
+        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        expect(jobFileFunctions.jobFileHandler)
+            .toThrow('JSON file contents cannot be empty');
         fs.unlinkSync(path.join(__dirname, '..', 'testFile.json'));
     });
 
-    it('response if metadata is not in file, but needs to be', () => {
+    it('should check if tjm data is in the job file', () => {
         const jsonFileData = {
             name: 'this is a name',
             version: '0.0.1',
@@ -53,20 +75,87 @@ describe('tests jsonDataFunctions', () => {
         jsonFileData.tjm = {
             clusters: ['http://localhost', 'http://cluster2']
         };
-        let jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
-        let metaDataCheckResponse = jobFileFunctions.metaDataCheck(jsonFileData);
-        expect(metaDataCheckResponse).toBe(true);
+
+        const argv = {};
+
+        let jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        expect(jobFileFunctions._tjmDataCheck(jsonFileData)).toBe(true);
         delete jsonFileData.tjm;
+
         // test metadata for job
         jsonFileData.tjm = {
             cluster: 'http://localhost'
         };
-        metaDataCheckResponse = jobFileFunctions.metaDataCheck(jsonFileData);
-        expect(metaDataCheckResponse).toBe(true);
+        expect(jobFileFunctions._tjmDataCheck(jsonFileData)).toBe(true);
 
         // test no metadata
         delete jsonFileData.tjm;
         jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')();
-        expect(jobFileFunctions.metaDataCheck).toThrow('No teraslice job manager metadata, register the job or deploy the assets');
+        expect(jobFileFunctions._tjmDataCheck).toThrow('No teraslice job manager metadata, register the job or deploy the assets');
+    });
+
+    it('cluster should be localhost', () => {
+        // create test file
+        fs.writeFileSync(path.join(__dirname,
+            '..',
+            'tfile.prod.json'),
+            JSON.stringify({ test: 'test' })
+        );
+
+        const argv = {
+            job_file: 'tfile.prod.json',
+            l: true
+        };
+
+        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+
+        const jobData = jobFileFunctions.returnJobData(true);
+        expect(argv.cluster).toBe('http://localhost:5678');
+        fs.unlinkSync(path.join(__dirname, '..', 'tfile.prod.json'));
+    });
+
+    it('cluster should be from jobFile', () => {
+        // create test file
+        fs.writeFileSync(path.join(__dirname, '..',
+            'fakeFile.json'),
+            JSON.stringify({ 
+                name: 'fakeJob',
+                tjm: {
+                    cluster: 'aclustername',
+                    job_id: 'jobid'
+                }
+            })
+        );
+
+        const argv = {
+            job_file: 'fakeFile.json',
+            tjm_check: true
+        };
+
+        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        const jobData = jobFileFunctions.returnJobData();
+        expect(argv.cluster).toBe('aclustername');
+        fs.unlinkSync(path.join(__dirname, '..', 'fakeFile.json'));
+    });
+
+    it('cluster should be from -c', () => {
+        // create test file
+        fs.writeFileSync(path.join(__dirname, '..',
+            'fakeFile2.json'),
+            JSON.stringify({ 
+                name: 'fakeJob',
+            })
+        );
+
+        const argv = {
+            job_file: 'fakeFile2.json',
+            c: 'someClusterName'
+        };
+
+        const jobFileFunctions = require('../cmds/cmd_functions/json_data_functions')(argv);
+        const jobData = jobFileFunctions.returnJobData(true);
+        expect(argv.cluster).toBe('someClusterName');
+        fs.unlinkSync(path.join(__dirname, '..', 'fakeFile2.json'));
     });
 });
+

--- a/spec/pause-spec.js
+++ b/spec/pause-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const pause = require('../cmds/pause');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;

--- a/spec/register-spec.js
+++ b/spec/register-spec.js
@@ -37,7 +37,7 @@ describe('register should register job with cluster and follow options', () => {
         argv.c = 'http://localhost:5678'
         const jobPath = path.join(__dirname, 'fixtures/regJobFile.json')
         fs.writeJsonSync(jobPath, fakeJobData, { spaces: 4 });
-        argv.jobFile = 'spec/fixtures/regJobFile.json';
+        argv.job_file = 'spec/fixtures/regJobFile.json';
         register.handler(argv, _testTJMFunctions)
             .then(done.fail)
             .catch(() => {
@@ -74,7 +74,7 @@ describe('register should register job with cluster and follow options', () => {
         argv.c = 'http://localhost:5678'
         const jobPath = path.join(__dirname, 'fixtures/regJobFile2.json')
         fs.writeJsonSync(jobPath, regJobData, { spaces: 4 });
-        argv.jobFile = 'spec/fixtures/regJobFile2.json';
+        argv.job_file = 'spec/fixtures/regJobFile2.json';
         return register.handler(argv, _testTJMFunctions)
             .then(() => {
                 const registeredJob = require(jobPath);

--- a/spec/reset-spec.js
+++ b/spec/reset-spec.js
@@ -15,7 +15,7 @@ describe('reset should remove tjm data from file', () => {
     it('tjm data should be pulled from file', () => {
         // copy fixture file
         const argv = {
-            jobFile: 'spec/fixtures/resetJobFile.json'
+            job_file: 'spec/fixtures/resetJobFile.json'
         };
 
         const fakeJobData = require('./fixtures/test_job_file.json');

--- a/spec/restart-spec.js
+++ b/spec/restart-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const restart = require('../cmds/restart');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;

--- a/spec/resume-spec.js
+++ b/spec/resume-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const resume = require('../cmds/resume');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;

--- a/spec/start-spec.js
+++ b/spec/start-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const start = require('../cmds/start');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;

--- a/spec/status-spec.js
+++ b/spec/status-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const status = require('../cmds/status');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;

--- a/spec/stop-spec.js
+++ b/spec/stop-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const stop = require('../cmds/stop');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;

--- a/spec/tjmFunctions-spec.js
+++ b/spec/tjmFunctions-spec.js
@@ -2,8 +2,8 @@
 
 const fs = require('fs-extra');
 
-const argv = {};
-let tjmFunctions = require('../cmds/cmd_functions/functions')(argv, 'localhost:5678');
+const tjmObject = {};
+let tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject, 'localhost:5678');
 const Promise = require('bluebird');
 const path = require('path');
 
@@ -61,13 +61,13 @@ describe('tjmFunctions testing', () => {
             }
         };
 
-        argv.job_file_content = jobContents;
-        argv.job_file_path = 'someFilePath';
-        argv.cluster = 'clustername';
+        tjmObject.job_file_content = jobContents;
+        tjmObject.job_file_path = 'someFilePath';
+        tjmObject.cluster = 'clustername';
 
         someJobId = 'jobYouAreLookingFor';
 
-        tjmFunctions = require('../cmds/cmd_functions/functions')(argv);
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
         tjmFunctions.__testContext(_teraslice);
         tjmFunctions.alreadyRegisteredCheck()
             .then(result => expect(result).toBe(true))
@@ -84,11 +84,11 @@ describe('tjmFunctions testing', () => {
             }
         };
 
-        argv.job_file_content = jobContents;
-        argv.job_file_path = 'someFilePath';
-        argv.cluster = 'clustername';
+        tjmObject.job_file_content = jobContents;
+        tjmObject.job_file_path = 'someFilePath';
+        tjmObject.cluster = 'clustername';
 
-        tjmFunctions = require('../cmds/cmd_functions/functions')(argv);
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
         tjmFunctions.__testContext(_teraslice);
         tjmFunctions.alreadyRegisteredCheck(jobContents)
             .catch((err) => {
@@ -105,11 +105,11 @@ describe('tjmFunctions testing', () => {
             cluster: 'clustername'
         }
 
-        argv.job_file_content = jobContents;
-        argv.job_file_path = 'someFilePath';
+        tjmObject.job_file_content = jobContents;
+        tjmObject.job_file_path = 'someFilePath';
 
         someJobId = 'jobYouAreLookingFor';
-        tjmFunctions = require('../cmds/cmd_functions/functions')(argv);
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
         tjmFunctions.alreadyRegisteredCheck()
             .catch((err) => {
                 expect(err.message).toEqual('No cluster configuration for this job');
@@ -118,10 +118,10 @@ describe('tjmFunctions testing', () => {
     });
 
     it('meta data is being written to assets.json ', () => {
-        argv.c = 'http://localhost:5678';
-        argv.cluster = argv.c;
+        tjmObject.c = 'http://localhost:5678';
+        tjmObject.cluster = tjmObject.c;
 
-        const tjmFuncs = require('../cmds/cmd_functions/functions')(argv);
+        const tjmFuncs = require('../cmds/cmd_functions/functions')(tjmObject);
         return createNewAsset()
             .then(() => tjmFuncs.__testFunctions()._updateAssetMetadata())
             .then((jsonResult) => {
@@ -143,10 +143,10 @@ describe('tjmFunctions testing', () => {
             return fs.writeFile(path.join(__dirname, '..', 'asset/asset.json'), JSON.stringify(assetJson, null, 4));
         })
         .then(() => {
-            argv.c = 'http://newCluster:5678';
-            argv.cluster = argv.c;
+            tjmObject.c = 'http://newCluster:5678';
+            tjmObject.cluster = tjmObject.c;
 
-            tjmFunctions = require('../cmds/cmd_functions/functions')(argv);
+            tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
             return tjmFunctions.__testFunctions()._updateAssetMetadata();
         })
         .then((jsonResult) => {
@@ -156,10 +156,10 @@ describe('tjmFunctions testing', () => {
         }));
 
     it('no asset.json throw error', () => {
-        argv.c = 'http://localhost:5678';
-        argv.cluster = argv.c;
+        tjmObject.c = 'http://localhost:5678';
+        tjmObject.cluster = tjmObject.c;
 
-        tjmFunctions = require('../cmds/cmd_functions/functions')(argv);
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
         return fs.emptyDir(path.join(__dirname, '..', 'asset'))
             .then(() => {
                 expect(tjmFunctions.__testFunctions()._updateAssetMetadata).toThrowError();
@@ -176,10 +176,10 @@ describe('tjmFunctions testing', () => {
             }
         };
 
-        argv.cluster = argv.c;
+        tjmObject.cluster = tjmObject.c;
 
-        argv.c = 'http://localhost:5678';
-        tjmFunctions = require('../cmds/cmd_functions/functions')(argv);
+        tjmObject.c = 'http://localhost:5678';
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
 
         return fs.writeJson(path.join(__dirname, '..', 'asset/asset.json'), assetJson, { spaces: 4 })
             .then(() => expect(tjmFunctions.__testFunctions()._updateAssetMetadata).toThrowError('Assets have already been deployed to http://localhost:5678, use update'));
@@ -227,9 +227,9 @@ describe('tjmFunctions testing', () => {
 
     xit('load asset removes build, adds metadata to asset, zips asset, posts to cluster', () => {
         assetObject = JSON.stringify({ success: 'this worked', _id: '1235fakejob' });
-        argv.c = 'localhost:5678';
-        argv.a = true;
-        tjmFunctions = require('../cmds/cmd_functions/functions')(argv);
+        tjmObject.c = 'localhost:5678';
+        tjmObject.a = true;
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
         tjmFunctions.__testContext(_teraslice);
 
         const assetJson = {

--- a/spec/tjmFunctions-spec.js
+++ b/spec/tjmFunctions-spec.js
@@ -2,8 +2,8 @@
 
 const fs = require('fs-extra');
 
-const tjmObject = {};
-let tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject, 'localhost:5678');
+const tjmConfig = {};
+let tjmFunctions = require('../cmds/cmd_functions/functions')(tjmConfig, 'localhost:5678');
 const Promise = require('bluebird');
 const path = require('path');
 
@@ -61,13 +61,13 @@ describe('tjmFunctions testing', () => {
             }
         };
 
-        tjmObject.job_file_content = jobContents;
-        tjmObject.job_file_path = 'someFilePath';
-        tjmObject.cluster = 'clustername';
+        tjmConfig.job_file_content = jobContents;
+        tjmConfig.job_file_path = 'someFilePath';
+        tjmConfig.cluster = 'clustername';
 
         someJobId = 'jobYouAreLookingFor';
 
-        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmConfig);
         tjmFunctions.__testContext(_teraslice);
         tjmFunctions.alreadyRegisteredCheck()
             .then(result => expect(result).toBe(true))
@@ -84,11 +84,11 @@ describe('tjmFunctions testing', () => {
             }
         };
 
-        tjmObject.job_file_content = jobContents;
-        tjmObject.job_file_path = 'someFilePath';
-        tjmObject.cluster = 'clustername';
+        tjmConfig.job_file_content = jobContents;
+        tjmConfig.job_file_path = 'someFilePath';
+        tjmConfig.cluster = 'clustername';
 
-        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmConfig);
         tjmFunctions.__testContext(_teraslice);
         tjmFunctions.alreadyRegisteredCheck(jobContents)
             .catch((err) => {
@@ -105,11 +105,11 @@ describe('tjmFunctions testing', () => {
             cluster: 'clustername'
         }
 
-        tjmObject.job_file_content = jobContents;
-        tjmObject.job_file_path = 'someFilePath';
+        tjmConfig.job_file_content = jobContents;
+        tjmConfig.job_file_path = 'someFilePath';
 
         someJobId = 'jobYouAreLookingFor';
-        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmConfig);
         tjmFunctions.alreadyRegisteredCheck()
             .catch((err) => {
                 expect(err.message).toEqual('No cluster configuration for this job');
@@ -118,10 +118,10 @@ describe('tjmFunctions testing', () => {
     });
 
     it('meta data is being written to assets.json ', () => {
-        tjmObject.c = 'http://localhost:5678';
-        tjmObject.cluster = tjmObject.c;
+        tjmConfig.c = 'http://localhost:5678';
+        tjmConfig.cluster = tjmConfig.c;
 
-        const tjmFuncs = require('../cmds/cmd_functions/functions')(tjmObject);
+        const tjmFuncs = require('../cmds/cmd_functions/functions')(tjmConfig);
         return createNewAsset()
             .then(() => tjmFuncs.__testFunctions()._updateAssetMetadata())
             .then((jsonResult) => {
@@ -143,10 +143,10 @@ describe('tjmFunctions testing', () => {
             return fs.writeFile(path.join(__dirname, '..', 'asset/asset.json'), JSON.stringify(assetJson, null, 4));
         })
         .then(() => {
-            tjmObject.c = 'http://newCluster:5678';
-            tjmObject.cluster = tjmObject.c;
+            tjmConfig.c = 'http://newCluster:5678';
+            tjmConfig.cluster = tjmConfig.c;
 
-            tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
+            tjmFunctions = require('../cmds/cmd_functions/functions')(tjmConfig);
             return tjmFunctions.__testFunctions()._updateAssetMetadata();
         })
         .then((jsonResult) => {
@@ -156,10 +156,10 @@ describe('tjmFunctions testing', () => {
         }));
 
     it('no asset.json throw error', () => {
-        tjmObject.c = 'http://localhost:5678';
-        tjmObject.cluster = tjmObject.c;
+        tjmConfig.c = 'http://localhost:5678';
+        tjmConfig.cluster = tjmConfig.c;
 
-        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmConfig);
         return fs.emptyDir(path.join(__dirname, '..', 'asset'))
             .then(() => {
                 expect(tjmFunctions.__testFunctions()._updateAssetMetadata).toThrowError();
@@ -176,10 +176,10 @@ describe('tjmFunctions testing', () => {
             }
         };
 
-        tjmObject.cluster = tjmObject.c;
+        tjmConfig.cluster = tjmConfig.c;
 
-        tjmObject.c = 'http://localhost:5678';
-        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
+        tjmConfig.c = 'http://localhost:5678';
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmConfig);
 
         return fs.writeJson(path.join(__dirname, '..', 'asset/asset.json'), assetJson, { spaces: 4 })
             .then(() => expect(tjmFunctions.__testFunctions()._updateAssetMetadata).toThrowError('Assets have already been deployed to http://localhost:5678, use update'));
@@ -227,9 +227,9 @@ describe('tjmFunctions testing', () => {
 
     xit('load asset removes build, adds metadata to asset, zips asset, posts to cluster', () => {
         assetObject = JSON.stringify({ success: 'this worked', _id: '1235fakejob' });
-        tjmObject.c = 'localhost:5678';
-        tjmObject.a = true;
-        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmObject);
+        tjmConfig.c = 'localhost:5678';
+        tjmConfig.a = true;
+        tjmFunctions = require('../cmds/cmd_functions/functions')(tjmConfig);
         tjmFunctions.__testContext(_teraslice);
 
         const assetJson = {

--- a/spec/update-spec.js
+++ b/spec/update-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const update = require('../cmds/update');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;

--- a/spec/view-spec.js
+++ b/spec/view-spec.js
@@ -7,7 +7,7 @@ const view = require('../cmds/view');
 const Promise = require('bluebird');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 let registeredCheck;
 let specData;

--- a/spec/workers-spec.js
+++ b/spec/workers-spec.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const workers = require('../cmds/workers');
 
 const argv = {
-    jobFile: 'spec/fixtures/test_job_file.json'
+    job_file: 'spec/fixtures/test_job_file.json'
 };
 
 let registeredCheck;


### PR DESCRIPTION
simplified tjm data check process for jobs files and removed redundant code
also renamed object properties to be consistent with other teraslice code and changed names to be more descriptive
removed the port/ http check since the port is not required and http will go to https at some point
addresses issues #24 and #28 